### PR TITLE
Added weekly weather API call

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -59,18 +59,19 @@ input {
 
 aside {
     float: left;
-    margin-top: 14.2%;
-    height: 300px;
+    margin-top: 11%;
+    height: 400px;
     width: 343px;
     /* border-style: solid; */
 }
 
 section {
+    position: relative;
     float: right;
     height: 300px;
-    width: 880px;
-    padding: 0% 0% 0% 0%;
-    /* border-style: solid; */
+    width: 75%;
+    padding: 0% 0% 0% 2%;
+    border-style: solid;
 }
 
 #city {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -34,8 +34,8 @@ var getCityWeather = function (city) {
   // Fetch request is sent for the apiUrl with user data
   fetch(apiUrl)
 
-    // After the fetch request is made it will then 
-    .then(function (response) {
+    // The data from the fetch request is then passed into response
+    .then(function(response) {
 
         // If the response for the fetch request is true or in this case 'ok'
         if (response.ok) {
@@ -64,30 +64,70 @@ var getCityWeather = function (city) {
 // Contains weather data from API call and stores them within variables
 function cityWeatherData(data) {
   var city = data.name;
-  var lon = data.coord.lon;
-  var lat = data.coord.lat;
-  var temp = data.main.temp;
   var humid = data.main.humidity;
   var wind = data.wind.speed;
-  var date = data.dt;
-  
-  console.log(city);
-  console.log(lon);
-  console.log(lat);
-  console.log(temp);
-  console.log(humid);
-  console.log(wind);
-  console.log(date);
-  
-  var currentWeather = `
-    <h1 id="city">${city} (${date})</h1>
-    <p>Temp: ${temp}</p>
-    <p>Wind: ${wind}</p>
-    <p>Humidity: ${humid}</p>`;
+  var icon = data.main.feels_like;
 
+  // variables that store the searched cities longitude and latitude for weekly weather data API call
+  var lon = data.coord.lon;
+  var lat = data.coord.lat;
+  
+  // Converts daily time (dt) from milliseconds to be utilized as the current day, month and year
+  var date = new Date(data.dt * 1000);
+
+  // Converts temperature from Kelvin to Fahrenheit while rounding up
+  var temp = Math.floor(((data.main.temp - 273.15) * 1.8) + 32);
+
+  console.log(icon);
+  
+  // HTML that will pass in the stored data we formatted from the API call
+  var currentWeather = `
+    <h1 id="city">${city}, ${date.toDateString()}</h1>
+    <p>Temp: ${temp}°F</p>
+    <p>Wind: ${wind} MPH</p>
+    <p>Humidity: ${humid}%</p>`;
+
+  // If there is data within all these variables to pass then it will return the HTML from the currentWeather variable while calling getWeeklyWeather w/ lat and lon as parameters
   if (city, date, temp, wind, humid) {
+    getWeeklyWeather(lat, lon);
     return section.innerHTML = currentWeather;
   }
+}
+
+// Function that will retrieve weekly weather data by taking in lat and lon variables
+var getWeeklyWeather = function (lat, lon) {
+
+  // API call that will use lat and lon w/ the API Key
+  var weekApiUrl = `https://api.openweathermap.org/data/2.5/forecast?lat=${lat}&lon=${lon}&appid=${APIKey}`;
+
+  // Fetch request is made with the weekApiUrl
+  fetch(weekApiUrl)
+
+  // Ferch request data from weekApiUrl is passed into response
+  .then(function(response) {
+
+    // If the response is valid then it will return the data in json format
+    if (response.ok) {
+        return response.json();
+
+    // Otherwise it will alert the webpage with a prompt and an error message
+    } else {
+        alert('Error: ' + response.statusText);
+    }
+  })
+
+  // JSON data is then passed into data and a call is made to the weeklyWeatherData function
+  .then(function(data) {
+    weeklyWeatherData(data)
+  })
+  .catch(function(error) {
+    console.log('Error: ' + error)
+  })
+}
+
+// Contains weekly weather data from weekApiUrl
+function weeklyWeatherData(data) {
+  console.log(data)
 }
 
 // When someone clicks the search button it will call the ping function

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </main>
 
         <footer>
-            <p>API provided by OpenWeather</p>
+            <p>API provided by OpenWeatherMap</p>
         </footer>
       <script src="./assets/js/index.js"></script>
     </body>


### PR DESCRIPTION
Since last push I've slightly adjusted 'style.css' for the front-end but I mainly adjusted 'index.js' by formatting the following JSON data from the API call for the current weather search:

- Date variable is now able to showcase the current day of the week, month, date and year on the webpage (Lines 76 and 85)
- Temp variable is now able to convert from Kelvin to Fahrenheit to display on the webpage while rounding up (Lines 79 and 86)
- Wind now has 'MPH' for speeds (Line 87)
- Humidity has a percentage icon displayed after it (Line 88)

I went ahead and used the same formula I did earlier to retrieve the weekly weather data but this time passing in the longitude and latitude data from Lines 72 and 73 to another function where they plug into the weekly weather API call (Line 101)

Finally I commented everything that made sense within 'index.js' while taking out some console.logs as they have since served their purpose and I adjusted the footer text to include the API companies full name in 'index.html'.

Next is figuring out the best way to implement the weekly data into 'index.js' and formatting the data to be passed through innerHTML and displayed properly on the webpage.